### PR TITLE
feat: recipients read and write

### DIFF
--- a/__test__/data.test.js
+++ b/__test__/data.test.js
@@ -1,7 +1,7 @@
 const { JWT } = require('@panva/jose')
 const { schemas } = require('@egendata/messaging')
 const { getWritePermissionPdsData, readPermission } = require('../lib/sqlStatements')
-const { write, read, readRecipients } = require('../lib/data')
+const { write, read, readRecipients, writeRecipients } = require('../lib/data')
 const { client } = require('../__mocks__/pg')
 const pdsAdapter = require('../lib/adapters/pds')
 
@@ -490,6 +490,77 @@ describe('data', () => {
         await expect(schemas[expectedType].validate(claimsSet))
           .resolves.not.toThrow()
       })
+    })
+  })
+  describe('#writeRecipients', () => {
+    let data
+    beforeEach(() => {
+      data = {
+        protected: 'eyJlbmMiOiJBMTI4Q0JDLUhTMjU2In0',
+        recipients: [
+          {
+            header: {
+              kid: 'http://localhost:64172/jwks/dQSdk8GhZeM4-IjSI0gkln7Mg0SG1vpOscOLZk65Iyw',
+              alg: 'RSA-OAEP'
+            },
+            encrypted_key: 'IjEIBdvEeNMAln6U0armHyfW-G8XYiSmcNVcIu8GBCyXNUt0rkbIQysncSATPa9etuuqQnvvsBYqEjXyllm26FNXJSZIaOOf7y1Nh_JlSnrqxEmnRW75D2I0d58yiB8meiuHbOWzRyyaOU1iyZ_Gw5y0ILiBQxIkVnM78KQuo_phk6hQo3wzXU4-IiC4p3Jypo-v5S8qlAlE-rk-1ykH0gj--ZdPYajLo-nE6nuB5bM0HOR8yL1R-57Gs2BBHh7CgSlUAkOLni7xtiKdL9vJZfeQ9NTJWqnhM9MX65JSsgMeTllMirALjoNvY35w0OGb8F7q29P23Co4MMs72iysWw'
+          },
+          {
+            header: {
+              kid: 'egendata://jwks/rhQX3s5x9y398fcmAaexW7u22dl-t2na2sCnqyDVCOU',
+              alg: 'RSA-OAEP'
+            },
+            encrypted_key: 'ncitnvyG6-LAqZ91qjb3aBWlUIU9CylR9W4LztLzvMSOGxneX__yhsPBB-S5jdeEdCYmgSxdEVT-PKCvoKM7Sqht2HRdXPJ-aEmUWhyFHzDKQ4AIjQUgTPyl8a9WKG9ncO5ZO9s6bKw1wRJph7mKKFb46t8CDLJOjghNRuOSorXCaAF9ekxFI1hAOFFOjcVnmVGTSVwtkTNzglMvG907IfIyqKD3mBvDfp7QLUKXV4AV_TIQ6j9vsD4moagdGCBlKT0YKraLMJChc2u-Mq7Bwxd9w2y-26W7G3aEDwvowp9kWmj9ZkKzJunL0KMEyXgny5cmfjqK68vjj87P3vpDmw'
+          }
+        ],
+        iv: 'CHIJCMomkqr-R7gxmXQ7RA',
+        ciphertext: 'Fj3b5Y3Zu_cKQUqos8xkrh0DIx73f-UYWOu9Dv5NfAHcJnaa_zYqb1Cbuian5oVm0632UuMHf9jng2xBZOZ6qfdWtID15dYwP8tSMizLU6_Qrt8tZCJI1nBDJ7hEUAqBPOde9bZSH8_uwSEsOKLoGHzVLXT3IIHsLo1ua1yBdFBjQJDPdBTpcJxgoZvOhQ3t5ftgAY7zgMpAfCZEwpbXSpOIo8ND5LxmDiPZV4AknyM3vDiWkKwiGzkiGCqB4d8C-8KOEz69HCocvYkfVUSpjCCWKsFc0txDcLnOwQp11oeINWU0RE3Ws2qxukoMN-DlcUZOgHh9AHbALNWfuu_8riqh6I2FXDVEnXJ1N7swzvkNo_TcXF8_Nj2_cIeST6u2',
+        tag: 'TiBled05Q4fysMyy72-z-g'
+      }
+      pds.readFile.mockResolvedValue(JSON.stringify(data))
+    })
+    it('can write new recipients to existing data', async () => {
+      const payload = {
+        type: 'RECIPIENTS_WRITE',
+        sub: '26eb214f-287b-4def-943c-55a6eefa2d91',
+        aud: 'https://smoothoperator.com',
+        iss: 'https://mycv.work',
+        paths: [
+          {
+            domain: 'https://mycv.work',
+            area: 'favorite_cats',
+            recipients: [
+              {
+                header: {
+                  kid: 'http://localhost:64172/jwks/dQSdk8GhZeM4-IjSI0gkln7Mg0SG1vpOscOLZk65Iyw',
+                  alg: 'RSA-OAEP'
+                },
+                encrypted_key: 'IjEIBdvEeNMAln6U0armHyfW-G8XYiSmcNVcIu8GBCyXNUt0rkbIQysncSATPa9etuuqQnvvsBYqEjXyllm26FNXJSZIaOOf7y1Nh_JlSnrqxEmnRW75D2I0d58yiB8meiuHbOWzRyyaOU1iyZ_Gw5y0ILiBQxIkVnM78KQuo_phk6hQo3wzXU4-IiC4p3Jypo-v5S8qlAlE-rk-1ykH0gj--ZdPYajLo-nE6nuB5bM0HOR8yL1R-57Gs2BBHh7CgSlUAkOLni7xtiKdL9vJZfeQ9NTJWqnhM9MX65JSsgMeTllMirALjoNvY35w0OGb8F7q29P23Co4MMs72iysWw'
+              },
+              {
+                header: {
+                  kid: 'egendata://jwks/rhQX3s5x9y398fcmAaexW7u22dl-t2na2sCnqyDVCOU',
+                  alg: 'RSA-OAEP'
+                },
+                encrypted_key: 'ncitnvyG6-LAqZ91qjb3aBWlUIU9CylR9W4LztLzvMSOGxneX__yhsPBB-S5jdeEdCYmgSxdEVT-PKCvoKM7Sqht2HRdXPJ-aEmUWhyFHzDKQ4AIjQUgTPyl8a9WKG9ncO5ZO9s6bKw1wRJph7mKKFb46t8CDLJOjghNRuOSorXCaAF9ekxFI1hAOFFOjcVnmVGTSVwtkTNzglMvG907IfIyqKD3mBvDfp7QLUKXV4AV_TIQ6j9vsD4moagdGCBlKT0YKraLMJChc2u-Mq7Bwxd9w2y-26W7G3aEDwvowp9kWmj9ZkKzJunL0KMEyXgny5cmfjqK68vjj87P3vpDmw'
+              },
+              {
+                header: {
+                  kid: 'http://newReaderdomain.com/jwks/qiHxZASLhpKMBebvqaTrNHiFgGGc1Febsx3P9satcdc',
+                  alg: 'RSA-OAEP'
+                },
+                encrypted_key: 'tBItAYQaJImcE_MITOdy8L86VkLSL5H7seEHWqwqciqKE3_Gfd-Pvn13Lw47x-j47xNT26JEqbnjzoME8DoQfR_LGU27hLe9KWAvdK1fpSH25Q5XP6pO4PRZddNbX8zz95T4H17qA4MlYkHRc-Sgi4WrC37XXJn3wI5pYFN_rRhqA_ndW98T7V1qwCGwClGvEzm58vYrkAIO5jN4dWkPS0Ghjmuc5tez7PVesVLPvHoRJlxXcRvwhfzcHEZP7T5MUpN9jZhh9gm7kApt66SenYcgZ3EOasCG4ty11F4paJ6hagC5jbNWqY6kpWDZqjF-QrcpboAP7Ao_r7HzjLej9Q'
+              }]
+          }
+        ],
+        iat: 1562150432,
+        exp: 1562154032
+      }
+      await writeRecipients({ header, payload }, res, next)
+
+      const expectedEntry = '{"domain":"https://mycv.work","area":"favorite_cats","data":{"recipients":[{"header":{"kid":"http://localhost:64172/jwks/dQSdk8GhZeM4-IjSI0gkln7Mg0SG1vpOscOLZk65Iyw","alg":"RSA-OAEP"},"encrypted_key":"IjEIBdvEeNMAln6U0armHyfW-G8XYiSmcNVcIu8GBCyXNUt0rkbIQysncSATPa9etuuqQnvvsBYqEjXyllm26FNXJSZIaOOf7y1Nh_JlSnrqxEmnRW75D2I0d58yiB8meiuHbOWzRyyaOU1iyZ_Gw5y0ILiBQxIkVnM78KQuo_phk6hQo3wzXU4-IiC4p3Jypo-v5S8qlAlE-rk-1ykH0gj--ZdPYajLo-nE6nuB5bM0HOR8yL1R-57Gs2BBHh7CgSlUAkOLni7xtiKdL9vJZfeQ9NTJWqnhM9MX65JSsgMeTllMirALjoNvY35w0OGb8F7q29P23Co4MMs72iysWw"},{"header":{"kid":"egendata://jwks/rhQX3s5x9y398fcmAaexW7u22dl-t2na2sCnqyDVCOU","alg":"RSA-OAEP"},"encrypted_key":"ncitnvyG6-LAqZ91qjb3aBWlUIU9CylR9W4LztLzvMSOGxneX__yhsPBB-S5jdeEdCYmgSxdEVT-PKCvoKM7Sqht2HRdXPJ-aEmUWhyFHzDKQ4AIjQUgTPyl8a9WKG9ncO5ZO9s6bKw1wRJph7mKKFb46t8CDLJOjghNRuOSorXCaAF9ekxFI1hAOFFOjcVnmVGTSVwtkTNzglMvG907IfIyqKD3mBvDfp7QLUKXV4AV_TIQ6j9vsD4moagdGCBlKT0YKraLMJChc2u-Mq7Bwxd9w2y-26W7G3aEDwvowp9kWmj9ZkKzJunL0KMEyXgny5cmfjqK68vjj87P3vpDmw"},{"header":{"kid":"http://newReaderdomain.com/jwks/qiHxZASLhpKMBebvqaTrNHiFgGGc1Febsx3P9satcdc","alg":"RSA-OAEP"},"encrypted_key":"tBItAYQaJImcE_MITOdy8L86VkLSL5H7seEHWqwqciqKE3_Gfd-Pvn13Lw47x-j47xNT26JEqbnjzoME8DoQfR_LGU27hLe9KWAvdK1fpSH25Q5XP6pO4PRZddNbX8zz95T4H17qA4MlYkHRc-Sgi4WrC37XXJn3wI5pYFN_rRhqA_ndW98T7V1qwCGwClGvEzm58vYrkAIO5jN4dWkPS0Ghjmuc5tez7PVesVLPvHoRJlxXcRvwhfzcHEZP7T5MUpN9jZhh9gm7kApt66SenYcgZ3EOasCG4ty11F4paJ6hagC5jbNWqY6kpWDZqjF-QrcpboAP7Ao_r7HzjLej9Q"}]}}'
+      const expectedPath = '/data/26eb214f-287b-4def-943c-55a6eefa2d91/https%3A%2F%2Fmycv.work/favorite_cats/data.json'
+      expect(pds.outputFile).toHaveBeenCalledWith(expectedPath, expectedEntry, 'utf8')
     })
   })
 })

--- a/__test__/messages.test.js
+++ b/__test__/messages.test.js
@@ -8,7 +8,8 @@ jest.mock('../lib/accounts', () => ({
 }))
 jest.mock('../lib/data', () => ({
   read: jest.fn(),
-  write: jest.fn()
+  write: jest.fn(),
+  readRecipients: jest.fn()
 }))
 jest.mock('../lib/services', () => ({
   registerService: jest.fn(),
@@ -78,6 +79,15 @@ describe('messages', () => {
         const token = 'sdhsdjhfgsjhfg'
         await handle({ header, payload, token }, res, next)
         expect(services.registerService).toHaveBeenCalledWith({ header, payload, token }, res, next)
+      })
+    })
+    describe('RECIPIENTS_READ_REQUEST', () => {
+      it('can get recipients for data', async () => {
+        const header = {}
+        const payload = { type: 'RECIPIENTS_READ_REQUEST' }
+        const token = 'sdhsdjhfgsjhfg'
+        await handle({ header, payload, token }, res, next)
+        expect(data.readRecipients).toHaveBeenCalledWith({ header, payload, token }, res, next)
       })
     })
   })

--- a/__test__/messages.test.js
+++ b/__test__/messages.test.js
@@ -9,7 +9,8 @@ jest.mock('../lib/accounts', () => ({
 jest.mock('../lib/data', () => ({
   read: jest.fn(),
   write: jest.fn(),
-  readRecipients: jest.fn()
+  readRecipients: jest.fn(),
+  writeRecipients: jest.fn()
 }))
 jest.mock('../lib/services', () => ({
   registerService: jest.fn(),
@@ -88,6 +89,15 @@ describe('messages', () => {
         const token = 'sdhsdjhfgsjhfg'
         await handle({ header, payload, token }, res, next)
         expect(data.readRecipients).toHaveBeenCalledWith({ header, payload, token }, res, next)
+      })
+    })
+    describe('RECIPIENTS_WRITE', () => {
+      it('can write recipients for data', async () => {
+        const header = {}
+        const payload = { type: 'RECIPIENTS_WRITE' }
+        const token = 'sdhsdjhfgsjhfg'
+        await handle({ header, payload, token }, res, next)
+        expect(data.writeRecipients).toHaveBeenCalledWith({ header, payload, token }, res, next)
       })
     })
   })

--- a/lib/data.js
+++ b/lib/data.js
@@ -22,10 +22,10 @@ async function getData (payload) {
   const reads = []
   for (const { rows } of result) {
     for (const row of rows) {
-      const { pdsProvider, pdsCredentials, domain, area } = camelCase(row)
+      const { pdsProvider, pdsCredentials, domain, area, dataPath } = camelCase(row)
       const { readFile } = get({ pdsProvider, pdsCredentials })
 
-      const path = getDataPath({ connectionId, domain, area })
+      const path = getDataPath({ connectionId, domain, area, dataPath })
       reads.push(
         readFile(path, 'utf8')
           .then(data => ({
@@ -93,10 +93,10 @@ async function write ({ payload }, res, next) {
   const writes = []
   for (const { rows } of results) {
     for (const row of rows) {
-      const { pdsProvider, pdsCredentials, domain, area } = camelCase(row)
+      const { pdsProvider, pdsCredentials, domain, area, dataPath } = camelCase(row)
       const { outputFile } = get({ pdsProvider, pdsCredentials })
 
-      const path = getDataPath({ connectionId, domain, area })
+      const path = getDataPath({ connectionId, domain, area, dataPath })
       const data = dataMap[domain] && dataMap[domain][area]
       if (data) {
         writes.push(outputFile(path, JSON.stringify(data), 'utf8'))
@@ -108,11 +108,9 @@ async function write ({ payload }, res, next) {
   res.sendStatus(200)
 }
 
-function getDataPath ({ connectionId, domain, area }) {
+function getDataPath ({ connectionId, domain, area, dataPath }) {
   return '/data' +
-         `/${encodeURIComponent(connectionId)}` +
-         `/${encodeURIComponent(domain)}` +
-         `/${encodeURIComponent(area)}` +
+         `/${encodeURIComponent(dataPath)}` +
          '/data.json'
 }
 
@@ -154,7 +152,7 @@ async function writeRecipients ({ payload }, res, next) {
   const metaData = camelCase(sqlResult)
   const permission = metaData.rows[0]
   const { readFile, outputFile } = get({ pdsProvider: permission.pdsProvider, pdsCredentials: permission.pdsCredentials })
-  const path = getDataPath({ connectionId, domain, area })
+  const path = getDataPath({ connectionId, domain, area, dataPath: permission.dataPath })
 
   return readFile(path, 'utf8')
     .then(data => ({

--- a/lib/data.js
+++ b/lib/data.js
@@ -24,9 +24,7 @@ async function getData (payload) {
       const { pdsProvider, pdsCredentials, domain, area } = camelCase(row)
       const { readFile } = get({ pdsProvider, pdsCredentials })
 
-      const path = `/data/${encodeURIComponent(
-        connectionId
-      )}/${encodeURIComponent(domain)}/${encodeURIComponent(area)}/data.json`
+      const path = getDataPath({ connectionId, domain, area })
       reads.push(
         readFile(path, 'utf8')
           .then(data => ({
@@ -77,7 +75,7 @@ function toDataMap (paths) {
 
 async function write ({ payload }, res, next) {
   const connectionId = payload.sub
-  const statements = payload.paths.map(({ domain, area }) =>
+  const sqlStatements = payload.paths.map(({ domain, area }) =>
     getWritePermissionPdsData({
       connectionId,
       domain,
@@ -85,23 +83,19 @@ async function write ({ payload }, res, next) {
       serviceId: payload.iss
     })
   )
-
-  const dataMap = toDataMap(payload.paths)
-  const results = await multiple(statements)
-  const writes = []
-
+  const results = await multiple(sqlStatements)
   if (results.every(({ rows }) => !rows.length)) {
     res.sendStatus(403).send('No valid permission')
   }
 
+  const dataMap = toDataMap(payload.paths)
+  const writes = []
   for (const { rows } of results) {
     for (const row of rows) {
       const { pdsProvider, pdsCredentials, domain, area } = camelCase(row)
       const { outputFile } = get({ pdsProvider, pdsCredentials })
 
-      const path = `/data/${encodeURIComponent(
-        connectionId
-      )}/${encodeURIComponent(domain)}/${encodeURIComponent(area)}/data.json`
+      const path = getDataPath({ connectionId, domain, area })
       const data = dataMap[domain] && dataMap[domain][area]
       if (data) {
         writes.push(outputFile(path, JSON.stringify(data), 'utf8'))
@@ -111,6 +105,14 @@ async function write ({ payload }, res, next) {
   await Promise.all(writes)
 
   res.sendStatus(200)
+}
+
+function getDataPath ({ connectionId, domain, area }) {
+  return '/data' +
+         `/${encodeURIComponent(connectionId)}` +
+         `/${encodeURIComponent(domain)}` +
+         `/${encodeURIComponent(area)}` +
+         '/data.json'
 }
 
 async function readRecipients ({ payload }, res, next) {

--- a/lib/data.js
+++ b/lib/data.js
@@ -1,5 +1,5 @@
 const { camelCase } = require('changecase-objects')
-const { writePermission, readPermission } = require('./sqlStatements')
+const { getWritePermissionPdsData, readPermission } = require('./sqlStatements')
 const { multiple } = require('./adapters/postgres')
 const { get } = require('./adapters/pds')
 const {
@@ -78,16 +78,22 @@ function toDataMap (paths) {
 async function write ({ payload }, res, next) {
   const connectionId = payload.sub
   const statements = payload.paths.map(({ domain, area }) =>
-    writePermission({
+    getWritePermissionPdsData({
       connectionId,
       domain,
       area,
       serviceId: payload.iss
     })
   )
+
   const dataMap = toDataMap(payload.paths)
   const results = await multiple(statements)
   const writes = []
+
+  if (results.every(({ rows }) => !rows.length)) {
+    res.sendStatus(403).send('No valid permission')
+  }
+
   for (const { rows } of results) {
     for (const row of rows) {
       const { pdsProvider, pdsCredentials, domain, area } = camelCase(row)

--- a/lib/data.js
+++ b/lib/data.js
@@ -125,7 +125,7 @@ async function readRecipients ({ payload }, res, next) {
       recipients: (path.data && path.data.recipients) || undefined
     }
   })
-  if(!paths.length) {
+  if (!paths.length) {
     console.error(`No data found for ${JSON.stringify(payload, null, 2)}`)
     return res.status(404)
   }
@@ -147,14 +147,13 @@ async function writeRecipients ({ payload }, res, next) {
     area,
     serviceId: payload.iss
   })
-  const sqlResult = await query(sqlStatement)
-  if (!sqlResult.length) {
-    res.sendStatus(403).send('No valid permission')
+  const sqlResult = await query(...sqlStatement)
+  if (!sqlResult.rowCount) {
+    return res.status(403).send('No valid permission')
   }
-
-  // läs datan
   const metaData = camelCase(sqlResult)
-  const { readFile, outputFile } = get({ pdsProvider: metaData.pdsProvider, pdsCredentials: metaData.pdsCredentials })
+  const permission = metaData.rows[0]
+  const { readFile, outputFile } = get({ pdsProvider: permission.pdsProvider, pdsCredentials: permission.pdsCredentials })
   const path = getDataPath({ connectionId, domain, area })
 
   return readFile(path, 'utf8')
@@ -163,10 +162,12 @@ async function writeRecipients ({ payload }, res, next) {
       area,
       data: data && JSON.parse(data)
     }))
-    // byt ut recipients i datan
-    .then(res => ({ ...res, data: { recipients: updatedRecipients } }))
-    // skriv uppdaterad data
+    .then(({ data }) => {
+      data.recipients = updatedRecipients
+      return data
+    })
     .then(entry => outputFile(path, JSON.stringify(entry), 'utf8'))
+    .then(() => res.sendStatus(200))
 }
 
 module.exports = {

--- a/lib/data.js
+++ b/lib/data.js
@@ -1,6 +1,7 @@
+
 const { camelCase } = require('changecase-objects')
 const { getWritePermissionPdsData, readPermission } = require('./sqlStatements')
-const { multiple } = require('./adapters/postgres')
+const { multiple, query } = require('./adapters/postgres')
 const { get } = require('./adapters/pds')
 const {
   createDataReadResponse,
@@ -124,7 +125,10 @@ async function readRecipients ({ payload }, res, next) {
       recipients: (path.data && path.data.recipients) || undefined
     }
   })
-
+  if(!paths.length) {
+    console.error(`No data found for ${JSON.stringify(payload, null, 2)}`)
+    return res.status(404)
+  }
   const token = await createRecipientsReadResponse(payload, paths)
   res
     .status(200)
@@ -132,8 +136,42 @@ async function readRecipients ({ payload }, res, next) {
     .send(token)
 }
 
+async function writeRecipients ({ payload }, res, next) {
+  // validera att användaren har signerat meddelandet
+
+  // hämta PDS-information för denna domain och area och connectionId, men inte serviceId?
+  const { sub: connectionId, paths: [{ domain, area, recipients: updatedRecipients }] } = payload
+  const sqlStatement = getWritePermissionPdsData({
+    connectionId,
+    domain,
+    area,
+    serviceId: payload.iss
+  })
+  const sqlResult = await query(sqlStatement)
+  if (!sqlResult.length) {
+    res.sendStatus(403).send('No valid permission')
+  }
+
+  // läs datan
+  const metaData = camelCase(sqlResult)
+  const { readFile, outputFile } = get({ pdsProvider: metaData.pdsProvider, pdsCredentials: metaData.pdsCredentials })
+  const path = getDataPath({ connectionId, domain, area })
+
+  return readFile(path, 'utf8')
+    .then(data => ({
+      domain,
+      area,
+      data: data && JSON.parse(data)
+    }))
+    // byt ut recipients i datan
+    .then(res => ({ ...res, data: { recipients: updatedRecipients } }))
+    // skriv uppdaterad data
+    .then(entry => outputFile(path, JSON.stringify(entry), 'utf8'))
+}
+
 module.exports = {
   read,
   readRecipients,
+  writeRecipients,
   write
 }

--- a/lib/messages.js
+++ b/lib/messages.js
@@ -10,7 +10,8 @@ const handlers = {
   LOGIN_RESPONSE: services.loginResponse,
   CONNECTION_RESPONSE: services.connectionResponse,
   SERVICE_REGISTRATION: services.registerService,
-  RECIPIENTS_READ_REQUEST: data.readRecipients
+  RECIPIENTS_READ_REQUEST: data.readRecipients,
+  RECIPIENTS_WRITE: data.writeRecipients
 }
 
 async function handle (req, res, next) {

--- a/lib/sqlStatements.js
+++ b/lib/sqlStatements.js
@@ -32,8 +32,8 @@ function permissionsInserts ({
   const sqlStatements = []
 
   // account_keys
-  const writePermissions = permissions.filter(wp => wp.type === 'WRITE')
-  for (const wp of writePermissions) {
+  const getWritePermissionPdsDatas = permissions.filter(wp => wp.type === 'WRITE')
+  for (const wp of getWritePermissionPdsDatas) {
     const accountKeys = wp.jwks.keys
       .filter(({ kid }) => rxAccountKey.test(kid))
 
@@ -135,7 +135,7 @@ function serviceInsert ({
   ]
 }
 
-function writePermission ({ connectionId, domain, area, serviceId }) {
+function getWritePermissionPdsData ({ connectionId, domain, area, serviceId }) {
   return [
     `
     SELECT
@@ -193,6 +193,6 @@ module.exports = {
   connectionInserts,
   permissionsInserts,
   serviceInsert,
-  writePermission,
+  getWritePermissionPdsData,
   readPermission
 }

--- a/lib/sqlStatements.js
+++ b/lib/sqlStatements.js
@@ -30,7 +30,6 @@ function permissionsInserts ({
 }, readKeys) {
   const rxAccountKey = /^egendata:\/\//
   const sqlStatements = []
-
   // account_keys
   const getWritePermissionPdsDatas = permissions.filter(wp => wp.type === 'WRITE')
   for (const wp of getWritePermissionPdsDatas) {
@@ -75,8 +74,9 @@ function permissionsInserts ({
         purpose,
         lawful_basis,
         read_key,
-        approved_at
-      ) VALUES($1, $2, $3, $4, $5, $6, $7, $8, $9, $10)
+        approved_at,
+        data_path
+      ) VALUES($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11)
       ON CONFLICT DO NOTHING`,
       [
         p.id,
@@ -88,7 +88,8 @@ function permissionsInserts ({
         p.purpose || null,
         p.lawfulBasis,
         readKey ? JSON.stringify(readKey) : null,
-        'now()'
+        'now()',
+        p.dataPath
       ]
     ])
   }
@@ -142,7 +143,8 @@ function getWritePermissionPdsData ({ connectionId, domain, area, serviceId }) {
       a.pds_provider,
       a.pds_credentials,
       p."domain",
-      p.area
+      p.area,
+      p.data_path
     FROM permissions as p
       INNER JOIN connections as c ON p.connection_id = c.connection_id
       INNER JOIN services as s ON c.service_id = s.service_id
@@ -167,7 +169,8 @@ function readPermission ({ connectionId, domain, area, serviceId }) {
       a.pds_provider,
       a.pds_credentials,
       p."domain",
-      p.area
+      p.area,
+      p.data_path
     FROM permissions as p
       INNER JOIN connections as c ON p.connection_id = c.connection_id
       INNER JOIN services as s ON c.service_id = s.service_id

--- a/migrations/1594986679154_add-dataPath-to-permission.js
+++ b/migrations/1594986679154_add-dataPath-to-permission.js
@@ -1,0 +1,13 @@
+/* eslint-disable camelcase */
+
+exports.shorthands = undefined
+
+exports.up = (pgm) => {
+  pgm.addColumns('permissions', {
+    data_path: { type: 'text' }
+  })
+}
+
+exports.down = (pgm) => {
+  pgm.dropColumns('permissions', 'data_path')
+}

--- a/package-lock.json
+++ b/package-lock.json
@@ -402,9 +402,9 @@
       }
     },
     "@egendata/messaging": {
-      "version": "0.7.0",
-      "resolved": "https://registry.npmjs.org/@egendata/messaging/-/messaging-0.7.0.tgz",
-      "integrity": "sha512-ayjMbCAPQRN0QXBPmEwRGFhEDSVb6FExpQ3Eg7X/LcaggsGHkKhDe0AEOSLHWunDmDR0dnfYI7k5Jx4fm2Wv9A==",
+      "version": "0.8.0",
+      "resolved": "https://registry.npmjs.org/@egendata/messaging/-/messaging-0.8.0.tgz",
+      "integrity": "sha512-2BjBUy0zaui0DorjJfec/dRpyHcJsiz3t3vxSm2D9uK9KoUM5Kq/O1LPypwuEflg5FR2DT+g8+7jmgwxd/EHmQ==",
       "requires": {
         "http-errors": "^1.7.3",
         "isomorphic-fetch": "^2.2.1",
@@ -8413,9 +8413,9 @@
       "integrity": "sha512-TfzJd2JaJ/lg/gU+q5j9rLAjnfUNF9DUmXTP9w+GfmG79LjFOXFeM7hIFuXCBcZCivUDFwd9l1btTV9rhHumtQ=="
     },
     "js-base64": {
-      "version": "2.5.1",
-      "resolved": "https://registry.npmjs.org/js-base64/-/js-base64-2.5.1.tgz",
-      "integrity": "sha512-M7kLczedRMYX4L8Mdh4MzyAMM9O5osx+4FcOQuTvr3A9F2D9S5JXheN0ewNbrvK2UatkTRhL5ejGmGSjNMiZuw=="
+      "version": "2.6.2",
+      "resolved": "https://registry.npmjs.org/js-base64/-/js-base64-2.6.2.tgz",
+      "integrity": "sha512-1hgLrLIrmCgZG+ID3VoLNLOSwjGnoZa8tyrUdEteMeIzsT6PH7PMLyUvbDwzNE56P3PNxyvuIOx4Uh2E5rzQIw=="
     },
     "js-tokens": {
       "version": "4.0.0",
@@ -17303,9 +17303,9 @@
       }
     },
     "whatwg-fetch": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/whatwg-fetch/-/whatwg-fetch-3.0.0.tgz",
-      "integrity": "sha512-9GSJUgz1D4MfyKU7KRqwOjXCXTqWdFNvEr7eUBYchQiVc744mqK/MzXPNR2WsPkmkOa4ywfg8C2n8h+13Bey1Q=="
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/whatwg-fetch/-/whatwg-fetch-3.1.0.tgz",
+      "integrity": "sha512-pgmbsVWKpH9GxLXZmtdowDIqtb/rvPyjjQv3z9wLcmgWKFHilKnZD3ldgrOlwJoPGOUluQsRPWd52yVkPfmI1A=="
     },
     "whatwg-mimetype": {
       "version": "2.3.0",

--- a/package.json
+++ b/package.json
@@ -27,7 +27,7 @@
   },
   "homepage": "https://github.com/egendata/operator#readme",
   "dependencies": {
-    "@egendata/messaging": "0.7.0",
+    "@egendata/messaging": "^0.8.0",
     "@panva/jose": "1.9.2",
     "axios": "0.19.0",
     "body-parser": "1.19.0",


### PR DESCRIPTION
Before: User could not read or add new recipients on a existing JWE.
After: User can retrieve a list of current recipients on a JWE as well as overwrite the existing recipients list.

Enables multiple parties to read the same data.